### PR TITLE
Localhost Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grupo-gcb/fast-ssm",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Fast SSM is a simple and lightweight lib to get parameter-score values from AWS with caching strategies.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,14 @@ export function getSync(params: GetParams): string | null {
       - logLevel: ${logLevel}; 
       - throwError: ${throwError}; 
       - defaultCacheTime: ${defaultCacheTime}; 
-      - region: ${region}`);
+      - region: ${region}
+      - localhostMode: ${params.localhostMode}`);
+
+  if(params.localhostMode) {
+    logger('get from default');
+
+    return params.default;
+  }
 
   const fromCache = getFromCache(params.path, params.cacheTime);
   if (fromCache?.expired === false) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,40 @@
 export type LogLevel = 'off' | 'error' | 'debug';
 
 export interface GetParams {
+  /**
+   * The ssm path.
+   */
   path: string;
+
+  /**
+   * The default value to return if the request fails or localhostMode is active.
+   */
   default?: string;
+
+  /**
+   * The time in minutes to cache the result. 
+   */
   cacheTime?: number;
+
+  /**
+   * The level of logging to perform.
+   */
   logLevel?: LogLevel;
+
+  /**
+   * Whether to throw an error on failure.
+   */
   throwError?: boolean;
+
+  /**
+   * AWS region.
+   */
   region?: string;
+
+  /**
+   * Whether to use localhost mode. In this mode, no request to ssm is made and the "default" value is returned.
+   */
+  localhostMode?: boolean;
 }
 
 export interface Cache {


### PR DESCRIPTION
Adicionando o localhostMode para que, se ativo, retorne somente os valores default. Essa implementação está sendo feita num contexto aonde apis que utilizam a lib precisam setar variaveis de ambiente em .env para execução de testes.  